### PR TITLE
Automatic death and ko

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2111,6 +2111,8 @@
   "SR5.INFO_DamageDropProne"                  : "drop prone because damages ({damage}) are greater than his physical limit ({limit})",
   "SR5.INFO_DamageDropProneGel"               : "drop prone because damages ({damage}) are greater than his physical limit ({limit}) modified by Gel rounds (-2)",
   "SR5.INFO_DamageDropProneTen"               : "drop prone because damages ({damage}) are greater than 10",
+  "SR5.INFO_DamageActorDead"                  : "is out of action.",
+  "SR5.INFO_DamageActorKo"                    : "is KO.",
   "SR5.WARN_NoForce"                          : "You don't have declared Force. Magic is applied by default.",
   "SR5.WARN_NoLevel"                          : "You don't have declared Level. Resonance is applied by default.",
   "SR5.WARN_NoActor"                          : "You must select an Actor first.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2111,6 +2111,8 @@
   "SR5.INFO_DamageDropProne"                  : "est projeté au sol car les dommages ({damage}) sont supérieurs à sa limite physique ({limit})",
   "SR5.INFO_DamageDropProneGel"               : "est projeté au sol car les dommages ({damage}) sont supérieurs à sa limite physique ({limit}) modifiée par les balles Gel (-2)",
   "SR5.INFO_DamageDropProneTen"               : "est projeté au sol car les dommages ({damage}) sont supérieurs à 10",
+  "SR5.INFO_DamageActorDead"                  : "est hors de combat.",
+  "SR5.INFO_DamageActorKo"                    : "est KO.",
   "SR5.WARN_NoForce"                          : "Vous n'avez pas défini de Puissance ! Par défaut Magie est appliquée.",
   "SR5.WARN_NoLevel"                          : "Vous n'avez pas défini de Niveau ! Par défaut Résonance est appliquée.",
   "SR5.WARN_NoActor"                          : "Vous devez sélectionner un Acteur !",

--- a/scripts/entities/actors/entityActor.js
+++ b/scripts/entities/actors/entityActor.js
@@ -615,6 +615,7 @@ export class SR5Actor extends Actor {
         if (damageType === "physical") {
           actorData.data.conditionMonitors.condition.current += damage;
           ui.notifications.info(`${this.name}: ${damage}${game.i18n.localize(SR5.damageTypesShort[damageType])} ${game.i18n.localize("SR5.Applied")}.`);
+          if (actorData.data.conditionMonitors.condition.current >= actorData.data.conditionMonitors.condition.value) await this.createDeadEffect();
           if (actorData.data.controlMode === "rigging"){
             let controler = SR5_EntityHelpers.getRealActorFromID(actorData.data.vehicleOwner.id)
             let chatData = {
@@ -635,6 +636,7 @@ export class SR5Actor extends Actor {
         if (options.matrixDamageValue) {
           actorData.data.conditionMonitors.matrix.current += options.matrixDamageValue;
           ui.notifications.info(`${this.name}: ${options.matrixDamageValue} ${game.i18n.localize("SR5.AppliedMatrixDamage")}.`);
+          if (actorData.data.conditionMonitors.matrix.current >= actorData.data.conditionMonitors.matrix.value) await this.createDeadEffect();
         }
         break;
     }

--- a/scripts/entities/actors/entityActor.js
+++ b/scripts/entities/actors/entityActor.js
@@ -577,8 +577,7 @@ export class SR5Actor extends Actor {
 
     switch (actorData.type){
       case "actorPc":
-      case "actorSpirit":
-        if (damage > (actorData.data.limits.physicalLimit.value + gelAmmo) || damage >= 10) await this.createProneEffect(damage, actorData, gelAmmo);
+      case "actorSpirit":  
         if (options.matrixDamageValue) {
           damage = options.matrixDamageValue;
           damageType = "stun";
@@ -599,11 +598,18 @@ export class SR5Actor extends Actor {
           actorData.data.conditionMonitors.overflow.current += carriedDamage;
           actorData.data.conditionMonitors.physical.current = actorData.data.conditionMonitors.physical.value;
         }
+
+        if (actorData.data.conditionMonitors.stun.current >= actorData.data.conditionMonitors.stun.value) await this.createKoEffect();
+        if (actorData.data.conditionMonitors.physical.current >= actorData.data.conditionMonitors.physical.value) await this.createDeadEffect();
+        if ((damage > (actorData.data.limits.physicalLimit.value + gelAmmo) || damage >= 10)
+          && actorData.data.conditionMonitors.stun.current < actorData.data.conditionMonitors.stun.value
+          && actorData.data.conditionMonitors.physical.current < actorData.data.conditionMonitors.physical.value) await this.createProneEffect(damage, actorData, gelAmmo);
         break;
       case "actorGrunt":
         actorData.data.conditionMonitors.condition.current += damage;
-        if (damage > (actorData.data.limits.physicalLimit.value + gelAmmo) || damage >= 10) await this.createProneEffect(damage, actorData, gelAmmo);
         ui.notifications.info(`${this.name}: ${damage}${game.i18n.localize(SR5.damageTypesShort[damageType])} ${game.i18n.localize("SR5.Applied")}.`);
+        if (actorData.data.conditionMonitors.condition.current >= actorData.data.conditionMonitors.condition.value) await this.createDeadEffect();
+        else if (damage > (actorData.data.limits.physicalLimit.value + gelAmmo) || damage >= 10) await this.createProneEffect(damage, actorData, gelAmmo);
         break;
       case "actorDrone":
         if (damageType === "physical") {
@@ -665,6 +671,50 @@ export class SR5Actor extends Actor {
     if (damage >= 10) ui.notifications.info(`${this.name}: ${game.i18n.format("SR5.INFO_DamageDropProneTen", {damage: damage})}`);
     else if (gelAmmo < 0) ui.notifications.info(`${this.name}: ${game.i18n.format("SR5.INFO_DamageDropProneGel", {damage: damage, limit: actorData.data.limits.physicalLimit.value})}`);
     else ui.notifications.info(`${this.name}: ${game.i18n.format("SR5.INFO_DamageDropProne", {damage: damage, limit: actorData.data.limits.physicalLimit.value})}`);
+  }
+
+  //Handle death effect
+  async createDeadEffect(){
+    for (let e of this.data.effects){
+      if (e.data.flags.core?.statusId === "dead") return;
+    }
+
+    let effect = {
+      label: game.i18n.localize("SR5.STATUSES_Dead_F"),
+      origin: "damageTaken",
+      icon: "systems/sr5/img/status/StatusDeadOn.svg",
+      flags: {
+        core: {
+            active: true,
+            statusId: "dead"
+        }
+      },
+    }
+
+    this.createEmbeddedDocuments('ActiveEffect', [effect]); 
+    ui.notifications.info(`${this.name}: ${game.i18n.localize("SR5.INFO_DamageActorDead")}`);
+  }
+
+  //Handle ko effect
+  async createKoEffect(){
+    for (let e of this.data.effects){
+      if (e.data.flags.core?.statusId === "unconscious") return;
+    }
+
+    let effect = {
+      label: game.i18n.localize("SR5.STATUSES_Unconscious_F"),
+      origin: "damageTaken",
+      icon: "systems/sr5/img/status/StatusUnconsciousOn.svg",
+      flags: {
+        core: {
+            active: true,
+            statusId: "unconscious"
+        }
+      },
+    }
+
+    this.createEmbeddedDocuments('ActiveEffect', [effect]); 
+    ui.notifications.info(`${this.name}: ${game.i18n.localize("SR5.INFO_DamageActorKo")}`);
   }
 
   //Handle Elemental Damage : Electricity

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -230,7 +230,7 @@ export const registerHooks = function () {
     combatant.update({
       "flags.sr5.seizeInitiative" : false,
       "flags.sr5.blitz" : false,
-      "flags.sr5.hasPlayed" : false,
+      "flags.sr5.hasPlayed" : combatant.isDefeated,
       "flags.sr5.cumulativeDefense" : 0,
       "flags.sr5.currentInitRating" : combatant.actor.data.data.initiatives[key].value,
       "flags.sr5.currentInitDice" : combatant.actor.data.data.initiatives[key].dice.value,
@@ -243,6 +243,14 @@ export const registerHooks = function () {
       actor = SR5_EntityHelpers.getRealActorFromID(combatant.data.tokenId)
     }
     actor.setFlag("sr5", "cumulativeDefense", 0);
+  });
+
+  Hooks.on("updateCombatant", (combatant) => {
+    if (combatant.isDefeated && !combatant.data.flags.sr5.hasPlayed){
+      combatant.update({
+        "flags.sr5.hasPlayed": true,
+      })
+    }
   });
 
   Hooks.on("updateItem", async(document, data, options, userId) => {

--- a/scripts/srcombat.js
+++ b/scripts/srcombat.js
@@ -84,7 +84,7 @@ export class SR5Combat extends Combat {
 			const initiative = SR5Combat.reduceIniResultAfterPass(Number(combatant.initiative));
 			await combatant.update({
 				initiative: initiative, 
-				"flags.sr5.hasPlayed": false,
+				"flags.sr5.hasPlayed": combatant.isDefeated,
 				"flags.sr5.baseCombatantInitiative": initiative,
 			});
 		}
@@ -103,7 +103,7 @@ export class SR5Combat extends Combat {
 			combatant.update({
 				"flags.sr5.seizeInitiative" : false,
 				"flags.sr5.blitz" : false,
-				"flags.sr5.hasPlayed" : false,
+				"flags.sr5.hasPlayed" : combatant.isDefeated,
 			  });
 			await SR5Combat.decreaseEffectDuration(combatant);
 		}
@@ -262,7 +262,7 @@ export class SR5Combat extends Combat {
 		// Let Foundry handle time and some other things.
 		await super.nextRound();
 		for (let combatant of this.combatants){
-			await combatant.setFlag("sr5", "hasPlayed", false)
+			await combatant.setFlag("sr5", "hasPlayed", combatant.isDefeated)
 		}
 
 		// Owner permissions are needed to change the shadowrun initiative round.
@@ -539,3 +539,10 @@ export const _getInitiativeFormula = function() {
 	const parts = [initiative, initiativeDice];
 	return parts.filter((p) => p !== null).join(" + ");
 }
+
+/*debugger;
+		if (combatant.isDefeated){
+			udpateData = mergeObject(udpateData, {
+				"flags.sr5.hasPlayed": true,
+			});
+		}*/

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "name": "sr5",
     "title": "Shadowrun 5",
     "description": "A comprehensive ruleset to play Shadowrun 5th Edition with Foundry VTT.",
-    "version": "0.0.3.0",
+    "version": "0.0.3.1",
     "author": "Karmaroms, deurk",
     "templateVersion": 2,
     "scripts": [],


### PR DESCRIPTION
By chat message button : 
- `Status effect 'Dead'` is automatically added when the main condition monitor of an `actor` is full.
- `Status effect 'KO'` is automatically added when the stun condition monitor of an `actor` is full.

If an `actor` has `Status effect 'Dead'` in the combat tracker, his turn is automatically skipped.