### PR TITLE
Fix scene background count

### DIFF
--- a/scripts/entities/actors/utilityActor.js
+++ b/scripts/entities/actors/utilityActor.js
@@ -2611,11 +2611,12 @@ export class SR5_CharacterUtility extends Actor {
 	// Background count calcultations
 	static updateBackgroundCount(actor){
 		let actorData = actor.system;
-		if (canvas.scene){
-			let token = canvas.scene?.tokens.find((t) => t.actorId === actor.id);
+		let scene = game.scenes.active;
+		if (scene){
+			let token = scene.tokens.find((t) => t.actorId === actor.id);
 			//check if actor already has a modifier on background count to avoid scene modifiers and prefer template modifier
 			if (token && !actorData.magic.bgCount.modifiers.length){
-				let sceneData = token.parent.flags.sr5;
+				let sceneData = scene.flags.sr5;
 				if (sceneData.backgroundCountValue !== 0) {
 					if (sceneData.backgroundCountAlignement === actorData.magic.tradition) SR5_EntityHelpers.updateModifier(actorData.magic.bgCount, game.i18n.localize("SR5.SceneBackgroundCount"), sceneData.backgroundCountAlignement, sceneData.backgroundCountValue, false, true);
 					else SR5_EntityHelpers.updateModifier(actorData.magic.bgCount, game.i18n.localize("SR5.SceneBackgroundCount"), sceneData.backgroundCountAlignement, -sceneData.backgroundCountValue, false, true);

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -393,5 +393,13 @@ export const registerHooks = function () {
 		if ( !game.user.isGM ) return;
 		await SR5_EffectArea.checkUpdatedTemplateEffect(templateDocument);
 	});
-	
+
+	Hooks.on('updateScene', async (data) => {
+		//relaunch prepare Data of all actor when a scene is modified, so background count and other effect are correctly applied without needing to manualy refresh an actor
+		if (!game.user.isGM) return;
+		for (let token of data.tokens){
+			token.actor.prepareData();
+			if (token.actor.sheet.rendered) token.actor.sheet.render(false);
+		}
+	});
 }


### PR DESCRIPTION
Background count for actor is now based on active scene.
Updating scenes modifiers now automatically update actors values.
closes https://github.com/shadowfoundry/sr5/issues/339